### PR TITLE
Fixed Python 3 bug in client code

### DIFF
--- a/sweetcaptcha/client.py
+++ b/sweetcaptcha/client.py
@@ -70,4 +70,4 @@ def check(app_id, app_key, sckey, scvalue):
 
 if __name__ == '__main__':
     import sys
-    print get_html(sys.argv[1], sys.argv[2])
+    print(get_html(sys.argv[1], sys.argv[2]))


### PR DESCRIPTION
I'm using Django with Python 3.4, and install failed due to a syntax error in the client code. This corrects that.
