### PR TITLE
Change to requests for great justice

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-sweetcaptcha',
-    version='0.1',
+    version='0.2',
     packages=['sweetcaptcha'],
     include_package_data=True,
     license='BSD License',
@@ -29,3 +29,4 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
 )
+

--- a/sweetcaptcha/client.py
+++ b/sweetcaptcha/client.py
@@ -39,7 +39,7 @@ def get_html(app_id, app_key, is_auto_submit=None, language=None):
         dict['is_auto_submit'] = 1
     if language:
         dict['language'] = language.upper()
-    fo = requests.get(SWEETCAPTCHA_API, params=data, verify=True)
+    fo = requests.post(SWEETCAPTCHA_API, params=data, verify=True)
     return fo.text()
 
 
@@ -56,7 +56,7 @@ def check(app_id, app_key, sckey, scvalue):
     """
     data = dict(app_id=app_id, app_key=app_key, platform='api',
                 method='check', sckey=sckey, scvalue=scvalue)
-    fo = requests.get(SWEETCAPTCHA_API, params=data, verify=True)
+    fo = requests.post(SWEETCAPTCHA_API, params=data, verify=True)
     return fo.text()
 
 

--- a/sweetcaptcha/client.py
+++ b/sweetcaptcha/client.py
@@ -11,7 +11,10 @@ sweetcaptcha.sweetcaptchawt.
 This module is executable.  Provide your app_id and app_key on the commandline
 to see the results of get_html
 """
-from urllib import urlencode
+try:
+    from urllib import urlencode
+except ImportError:
+    from urllib.parse import urlencode
 import urllib2
 
 SWEETCAPTCHA_API = 'http://sweetcaptcha.com/api'

--- a/sweetcaptcha/client.py
+++ b/sweetcaptcha/client.py
@@ -33,14 +33,18 @@ def get_html(app_id, app_key, is_auto_submit=None, language=None):
     :return: HTML code to be implemented within your FORM tag (before the
     submit button)
     """
-    data = dict(app_id=app_id, app_key=app_key, platform='api',
-                method='get_html')
+    data = dict(
+                platform='api',
+                method='get_html',
+                app_id=app_id,
+                app_key=app_key,
+                )
     if is_auto_submit:
         dict['is_auto_submit'] = 1
     if language:
         dict['language'] = language.upper()
-    fo = requests.post(SWEETCAPTCHA_API, params=data, verify=True)
-    return fo.text()
+    fo = requests.post(SWEETCAPTCHA_API, data=data, verify=True)
+    return fo.text
 
 
 def check(app_id, app_key, sckey, scvalue):
@@ -56,10 +60,13 @@ def check(app_id, app_key, sckey, scvalue):
     """
     data = dict(app_id=app_id, app_key=app_key, platform='api',
                 method='check', sckey=sckey, scvalue=scvalue)
-    fo = requests.post(SWEETCAPTCHA_API, params=data, verify=True)
-    return fo.text()
+    fo = requests.post(SWEETCAPTCHA_API, data=data, verify=True)
+    return fo.text
 
 
 if __name__ == '__main__':
     import sys
+    import logging
+    logging.basicConfig()
+    logging.getLogger().setLevel(logging.DEBUG)
     print(get_html(sys.argv[1], sys.argv[2]))

--- a/sweetcaptcha/client.py
+++ b/sweetcaptcha/client.py
@@ -13,9 +13,11 @@ to see the results of get_html
 """
 try:
     from urllib import urlencode
+    import urllib2
 except ImportError:
     from urllib.parse import urlencode
-import urllib2
+    import urllib.parse as urllib2
+
 
 SWEETCAPTCHA_API = 'http://sweetcaptcha.com/api'
 

--- a/sweetcaptcha/client.py
+++ b/sweetcaptcha/client.py
@@ -16,7 +16,7 @@ try:
     import urllib2
 except ImportError:
     from urllib.parse import urlencode
-    import urllib.parse as urllib2
+    import urllib.request as urllib2
 
 
 SWEETCAPTCHA_API = 'http://sweetcaptcha.com/api'

--- a/sweetcaptcha/client.py
+++ b/sweetcaptcha/client.py
@@ -13,7 +13,7 @@ to see the results of get_html
 """
 import requests
 
-SWEETCAPTCHA_API = 'http://sweetcaptcha.com/api'
+SWEETCAPTCHA_API = 'https://sweetcaptcha.com/api'
 
 
 def get_html(app_id, app_key, is_auto_submit=None, language=None):
@@ -39,7 +39,7 @@ def get_html(app_id, app_key, is_auto_submit=None, language=None):
         dict['is_auto_submit'] = 1
     if language:
         dict['language'] = language.upper()
-    fo = requests.get(SWEETCAPTCHA_API, params=data)
+    fo = requests.get(SWEETCAPTCHA_API, params=data, verify=True)
     return fo.text()
 
 
@@ -56,7 +56,7 @@ def check(app_id, app_key, sckey, scvalue):
     """
     data = dict(app_id=app_id, app_key=app_key, platform='api',
                 method='check', sckey=sckey, scvalue=scvalue)
-    fo = requests.get(SWEETCAPTCHA_API, params=data)
+    fo = requests.get(SWEETCAPTCHA_API, params=data, verify=True)
     return fo.text()
 
 

--- a/sweetcaptcha/client.py
+++ b/sweetcaptcha/client.py
@@ -44,6 +44,8 @@ def get_html(app_id, app_key, is_auto_submit=None, language=None):
     if language:
         dict['language'] = language.upper()
     fo = requests.post(SWEETCAPTCHA_API, data=data, verify=True)
+    if fo.status_code != 200:
+        raise Exception(fo.text)
     return fo.text
 
 
@@ -61,10 +63,16 @@ def check(app_id, app_key, sckey, scvalue):
     data = dict(app_id=app_id, app_key=app_key, platform='api',
                 method='check', sckey=sckey, scvalue=scvalue)
     fo = requests.post(SWEETCAPTCHA_API, data=data, verify=True)
+    if fo.status_code != 200:
+        raise Exception(fo.text)
     return fo.text
 
 
 if __name__ == '__main__':
+    """For testing a debugging, run this script via the python interpeter.
+    First argument is the app_id and the second is the app_key
+    Runs with debugging output on to the console.
+    """
     import sys
     import logging
     logging.basicConfig()

--- a/sweetcaptcha/client.py
+++ b/sweetcaptcha/client.py
@@ -11,13 +11,7 @@ sweetcaptcha.sweetcaptchawt.
 This module is executable.  Provide your app_id and app_key on the commandline
 to see the results of get_html
 """
-try:
-    from urllib import urlencode
-    import urllib2
-except ImportError:
-    from urllib.parse import urlencode
-    import urllib.request as urllib2
-
+import requests
 
 SWEETCAPTCHA_API = 'http://sweetcaptcha.com/api'
 
@@ -45,14 +39,8 @@ def get_html(app_id, app_key, is_auto_submit=None, language=None):
         dict['is_auto_submit'] = 1
     if language:
         dict['language'] = language.upper()
-    data = urlencode(data)
-    fo = urllib2.urlopen(SWEETCAPTCHA_API, data)
-    html = []
-    data = fo.read()
-    while data:
-        html.append(data)
-        data = fo.read()
-    return ''.join(html)
+    fo = requests.get(SWEETCAPTCHA_API, params=data)
+    return fo.text()
 
 
 def check(app_id, app_key, sckey, scvalue):
@@ -68,9 +56,8 @@ def check(app_id, app_key, sckey, scvalue):
     """
     data = dict(app_id=app_id, app_key=app_key, platform='api',
                 method='check', sckey=sckey, scvalue=scvalue)
-    data = urlencode(data)
-    fo = urllib2.urlopen(SWEETCAPTCHA_API, data)
-    return 'true' == fo.read()
+    fo = requests.get(SWEETCAPTCHA_API, params=data)
+    return fo.text()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I changed the transport mechanism to requests for many reasons. You can see a long story of why through my commit history. Using the httplib stuff is a mess in Python 3, requests takes care of all of it. I've also moved all the API requests to go over HTTPS with certificate verification, and added error handling for when problems occur with the API. Because of all of these changes, I also bumped the version of the library to 0.2 (just to make my testing easier). Feedback welcome!
